### PR TITLE
Set mobile homepage images to 16:9 aspect ratio

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -466,6 +466,7 @@ const availableMonth = futureDate.toLocaleDateString('en-US', { month: 'long', y
 
     .project-hero-image {
       margin-bottom: 1rem;
+      aspect-ratio: 16 / 9;
     }
 
     .project {


### PR DESCRIPTION
Standardize hero image aspect ratio on the mobile home page to ensure all images are consistently 16:9.

---
<a href="https://cursor.com/background-agent?bcId=bc-95376ce0-fc3a-42cb-abd4-1350813bf4d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95376ce0-fc3a-42cb-abd4-1350813bf4d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

